### PR TITLE
Refactor reply to text

### DIFF
--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -151,8 +151,7 @@ class WebhookController < ApplicationController
   def reply_to_text(input_text)
     case input_text
     when 'change-string'
-      @user.update(changing_suffix: true)
-      '後ろに付けたい文字列を入れてくださいチャー'
+      reply_to_change_string
     when 'change-to-char', 'change-to-masa'
       suffix = input_text == 'change-to-char' ? 'チャー' : 'まさ'
       @user.update(suffix: suffix, changing_suffix: false)
@@ -165,6 +164,13 @@ class WebhookController < ApplicationController
         input_text + @user&.suffix
       end
     end
+  end
+
+  # メッセージ 'change-string' を受け取った場合の処理.
+  # @return 返すテキストメッセージ
+  def reply_to_change_string
+    @user.update(changing_suffix: true)
+    '後ろに付けたい文字列を入れてくださいチャー'
   end
 
   # メッセージを送信する.

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -165,11 +165,11 @@ class WebhookController < ApplicationController
   # @return [String] 返すテキストメッセージ
   def reply_to_change_string
     @user.update(changing_suffix: true)
-    '後ろに付けたい文字列を入れてくださいチャー'
+    'うしろにつけたいテキストを送ってくださいチャー'
   end
 
-  # 後ろに付ける文字列を設定してテキストメッセージを返す.
-  # @param [String] new_suffix 新しく後ろに付ける文字列
+  # うしろに付けるテキストを設定してテキストメッセージを返す.
+  # @param [String] new_suffix 新しくうしろに付けるテキスト
   # @return [String] 返すテキストメッセージ
   def change_suffix_and_reply(new_suffix)
     @user.update(suffix: new_suffix, changing_suffix: false)

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -146,8 +146,8 @@ class WebhookController < ApplicationController
   end
 
   # text メッセージを受け取った場合の処理.
-  # @param text 受け取ったテキスト
-  # @return 返すテキストメッセージ
+  # @param [String] input_text 受け取ったテキスト
+  # @return [String] 返すテキストメッセージ
   def reply_to_text(input_text)
     case input_text
     when 'change-string'
@@ -167,7 +167,7 @@ class WebhookController < ApplicationController
   end
 
   # メッセージ 'change-string' を受け取った場合の処理.
-  # @return 返すテキストメッセージ
+  # @return [String] 返すテキストメッセージ
   def reply_to_change_string
     @user.update(changing_suffix: true)
     '後ろに付けたい文字列を入れてくださいチャー'

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -155,11 +155,9 @@ class WebhookController < ApplicationController
     when 'change-to-char', 'change-to-masa'
       change_suffix_and_reply(input_text == 'change-to-char' ? 'チャー' : 'まさ')
     else
-      if @user.changing_suffix
-        change_suffix_and_reply(input_text)
-      else
-        input_text + @user&.suffix
-      end
+      return change_suffix_and_reply(input_text) if @user.changing_suffix
+
+      input_text + @user&.suffix
     end
   end
 

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -158,8 +158,7 @@ class WebhookController < ApplicationController
       "#{suffix}に切り替えました！"
     else
       if @user.changing_suffix
-        @user.update(suffix: input_text, changing_suffix: false)
-        "#{input_text}に切り替えました！"
+        change_suffix_and_reply(input_text)
       else
         input_text + @user&.suffix
       end
@@ -171,6 +170,14 @@ class WebhookController < ApplicationController
   def reply_to_change_string
     @user.update(changing_suffix: true)
     '後ろに付けたい文字列を入れてくださいチャー'
+  end
+
+  # 後ろに付ける文字列を設定してテキストメッセージを返す.
+  # @param [String] new_suffix 新しく後ろに付ける文字列
+  # @return [String] 返すテキストメッセージ
+  def change_suffix_and_reply(new_suffix)
+    @user.update(suffix: new_suffix, changing_suffix: false)
+    "#{new_suffix}に切り替えました！"
   end
 
   # メッセージを送信する.

--- a/app/controllers/webhook_controller.rb
+++ b/app/controllers/webhook_controller.rb
@@ -153,9 +153,7 @@ class WebhookController < ApplicationController
     when 'change-string'
       reply_to_change_string
     when 'change-to-char', 'change-to-masa'
-      suffix = input_text == 'change-to-char' ? 'チャー' : 'まさ'
-      @user.update(suffix: suffix, changing_suffix: false)
-      "#{suffix}に切り替えました！"
+      change_suffix_and_reply(input_text == 'change-to-char' ? 'チャー' : 'まさ')
     else
       if @user.changing_suffix
         change_suffix_and_reply(input_text)

--- a/test/controllers/webhook_controller_test.rb
+++ b/test/controllers/webhook_controller_test.rb
@@ -34,8 +34,8 @@ class WebhookControllerTest < ActionDispatch::IntegrationTest
   end
 
   # change-string 関連
-  test "'change-string'に対してメッセージ'後ろに付けたい文字列を入れてくださいチャー'を返す" do
-    text = '後ろに付けたい文字列を入れてくださいチャー'
+  test "'change-string'に対してメッセージ'うしろにつけたいテキストを送ってくださいチャー'を返す" do
+    text = 'うしろにつけたいテキストを送ってくださいチャー'
     post callback_path, params: text_message_events('change-string')
     assert_response :success
     assert_equal reply_message(text), assigns(:message)
@@ -47,7 +47,7 @@ class WebhookControllerTest < ActionDispatch::IntegrationTest
     assert assigns(:user).changing_suffix
   end
 
-  test "'change-string'を送った後に一般の文字列を送ったとき" do
+  test "'change-string'を送った後に一般のメッセージを送ったとき" do
     text = 'ほげに切り替えました！'
     post callback_path, params: text_message_events('ほげ', 'hoge3')
     assert_response :success
@@ -56,7 +56,7 @@ class WebhookControllerTest < ActionDispatch::IntegrationTest
     assert_equal assigns(:user).suffix, 'ほげ'
   end
 
-  test "'change-string'を送った後に文字列'change-to-char'を送ったとき" do
+  test "'change-string'を送った後にメッセージ'change-to-char'を送ったとき" do
     text = 'チャーに切り替えました！'
     post callback_path, params: text_message_events('change-to-char', 'hoge3')
     assert_response :success
@@ -65,7 +65,7 @@ class WebhookControllerTest < ActionDispatch::IntegrationTest
     assert_equal assigns(:user).suffix, 'チャー'
   end
 
-  test "'change-string'を送った後に文字列'change-to-masa'を送ったとき" do
+  test "'change-string'を送った後にメッセージ'change-to-masa'を送ったとき" do
     text = 'まさに切り替えました！'
     post callback_path, params: text_message_events('change-to-masa', 'hoge3')
     assert_response :success


### PR DESCRIPTION
メソッド reply_to_text の rubocop 対応.
うしろに付ける文字列を変えるときのメッセージを修正.